### PR TITLE
feat: Allow a guarantee to keep at least N images

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   skip-tags:
     description: 'Restrict deletions to images without specific tags.'
     required: false
+  keep-at-least:
+    description: 'How many images to keep no matter what. Defaults to 0 which means you might delete everything'
+    required: false
 
 runs:
   using: 'docker'
@@ -44,3 +47,4 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.untagged-only }}
     - ${{ inputs.skip-tags }}
+    - ${{ inputs.keep-at-least }}


### PR DESCRIPTION
This feature is meant to allow a user to guarantee that they'll always
have at least N number of images. Since this action currently only
operates on time, if you have a service that doesn't update often, you
run the risk of deleting all of your images. Using `keep-at-least`
should give you the ability to keep N number of images. For example,
keep just the latest image.

To keep compatibility with the existing action, the default behavior
that happens if you don't specify `keep-at-least` is to keep 0 images.

Closes #3 