### PR TITLE
fix keep at least default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ inputs:
   keep-at-least:
     description: 'How many images to keep no matter what. Defaults to 0 which means you might delete everything'
     required: false
+    default: '0'
 
 runs:
   using: 'docker'


### PR DESCRIPTION
Looks like a non-specified option results in `''` being passed in rather than `None`. This makes sense, but wasn't fully handled, so running the action without a set value for the new setting crashes the workflow.

![image](https://user-images.githubusercontent.com/25310870/138646265-3e9223a4-20bb-436e-800f-6e54f88a5927.png)
