### PR TITLE
implement wildcard support for `skip_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Restricts image deletion to images without any tags, if enabled.
 ## skip-tags
 
 * **Required**: `No`
-* **Example**: `latest`
+* **Example**: `latest, v*`
 
 Restrict deletions to images without specific tags, if specified.
+
+Supports Unix-shell style wildcards, i.e 'v*' to match all tags starting with 'v'.
 
 # Nice to knows
 

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
     default: 'false'
   skip-tags:
-    description: 'Restrict deletions to images without specific tags.'
+    description: "Restrict deletions to images without specific tags. Supports Unix-shell style wildcards"
     required: false
   keep-at-least:
     description: 'How many images to keep no matter what. Defaults to 0 which means you might delete everything'

--- a/main_tests.py
+++ b/main_tests.py
@@ -208,7 +208,20 @@ class TestGetAndDeleteOldVersions:
         data[0]['metadata'] = {'container': {'tags': ['abc', 'bcd']}}
 
         Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
-        inputs = Inputs(**self.valid_inputs | {'skip_tags': 'abc'})
+        inputs = Inputs(**self.valid_inputs | {'skip_tags': ['abc']})
+
+        await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
+
+        captured = capsys.readouterr()
+        assert captured.out == 'No more versions to delete for a\n'
+
+    @pytest.mark.asyncio
+    async def test_skip_tags_wildcard(self, capsys):
+        data = deepcopy(self.valid_data)
+        data[0]['metadata'] = {'container': {'tags': ['v1.0.0', 'abc']}}
+
+        Inputs.list_package_versions = partial(self._mock_list_package_versions, data)
+        inputs = Inputs(**self.valid_inputs | {'skip_tags': ['v*']})
 
         await get_and_delete_old_versions(image_name=ImageName('a', 'a'), inputs=inputs, http_client=mock_http_client)
 


### PR DESCRIPTION
uses fnmatch for Unix shell-style wildcards

resolves #9