### PR TITLE
chore: Add pytest-socket as a dev dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -332,6 +332,17 @@ pytest = ">=5.0"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
+name = "pytest-socket"
+version = "0.5.1"
+description = "Pytest Plugin to disable socket calls during tests"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+pytest = ">=3.6.3"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -458,7 +469,7 @@ test = ["pytest-mock (>=3.3)", "pytest (>=4.3)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "2f5892610640114e9b47fdfda8a61c267f46008ffb92dd4f3e48ba71ee0139e8"
+content-hash = "00e750cbd61cc53150f6608c61a3780cf331c91cb686166722459cdb349be343"
 
 [metadata.files]
 anyio = [
@@ -642,6 +653,10 @@ pytest-cov = [
 pytest-mock = [
     {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
     {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
+]
+pytest-socket = [
+    {file = "pytest-socket-0.5.1.tar.gz", hash = "sha256:7c4b81dc6a51cbc0093f11791de00ff4a15ac698f5da96879a80f5d9ad4179b6"},
+    {file = "pytest_socket-0.5.1-py3-none-any.whl", hash = "sha256:8726fd47b83b127451532b6d570c5b6c4cd204fca363936509b1f53195de6f4f"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pytest-asyncio = "^0.15.1"
 pytest-cov = "^2.12.1"
 coverage = {extras = ["toml"], version = "^6.0.2"}
 black = {version = "^21.12b0", allow-prereleases = true}
+pytest-socket = "^0.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
 [tool:pytest]
-addopts = --cov=main --cov-report term-missing
+addopts =
+    --cov=main
+    --cov-report term-missing
+    # forbid external i/o in tests
+    --allow-hosts=127.0.0.1
 
 [flake8]
 exclude = main_tests.py


### PR DESCRIPTION
This blocks any IO during tests, just in case we forget a mock.