### PR TITLE
Add a dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ Supports Unix-shell style wildcards, i.e 'sha-*' to match all tags starting with
 
 Whether to consider untagged images for deletion.
 
+## dry-run
+
+* **Required**: `No`
+* **Default**: `false`
+
+Prints output showing imaages which would be deleted but does not actually delete any images.
+
 # Outputs
 
 ## deleted

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "Whether to consider untagged images for deletion."
     required: false
     default: 'true'
+  dry-run:
+    description: "Do not actually delete images. Print output showing what would have been deleted."
+    required: false
+    default: 'false'
 outputs:
   needs-github-assistance:
     description: 'Comma-separated list of image names and tags, for image versions that are public and have more than 5000 downloads.'
@@ -84,7 +88,8 @@ runs:
           "$SKIP_TAGS" \
           "$KEEP_AT_LEAST" \
           "$FILTER_TAGS" \
-          "$FILTER_INCLUDE_UNTAGGED"
+          "$FILTER_INCLUDE_UNTAGGED" \
+          "$DRY_RUN"
       env:
           ACCOUNT_TYPE: "${{ inputs.account-type }}"
           ORG_NAME: "${{ inputs.org-name }}"
@@ -97,3 +102,4 @@ runs:
           KEEP_AT_LEAST: "${{ inputs.keep-at-least }}"
           FILTER_TAGS: "${{ inputs.filter-tags }}"
           FILTER_INCLUDE_UNTAGGED: "${{ inputs.filter-include-untagged }}"
+          DRY_RUN: "${{ inputs.dry-run }}"

--- a/main.py
+++ b/main.py
@@ -388,9 +388,7 @@ async def get_and_delete_old_versions(image_name: str, inputs: Inputs, http_clie
 
             if inputs.dry_run:
                 delete_image = False
-                image_name_with_tag = f'{image_name}:{version.id}'
-                print(f'Would delete image {image_name_with_tag}.')
-                deleted.append(image_name_with_tag)
+                print(f'Would delete image {image_name}:{version.id}.')
 
             if delete_image:
                 tasks.append(

--- a/main.py
+++ b/main.py
@@ -298,6 +298,7 @@ class Inputs(BaseModel):
     keep_at_least: conint(ge=0) = 0  # type: ignore[valid-type]
     filter_tags: list[str]
     filter_include_untagged: bool = True
+    dry_run: bool = False
 
     @validator('skip_tags', 'filter_tags', 'image_names', pre=True)
     def parse_comma_separate_string_as_list(cls, v: str) -> list[str]:
@@ -385,6 +386,12 @@ async def get_and_delete_old_versions(image_name: str, inputs: Inputs, http_clie
                     # Skipping because this image version is tagged with a protected tag
                     delete_image = False
 
+            if inputs.dry_run:
+                delete_image = False
+                image_name_with_tag = f'{image_name}:{version.id}'
+                print(f'Would delete image {image_name_with_tag}.')
+                deleted.append(image_name_with_tag)
+
             if delete_image:
                 tasks.append(
                     asyncio.create_task(
@@ -460,6 +467,7 @@ async def main(
     keep_at_least: str,
     filter_tags: str,
     filter_include_untagged: str,
+    dry_run: str = 'false',
 ) -> None:
     """
     Delete old image versions.
@@ -486,6 +494,8 @@ async def main(
     :param filter_tags: Comma-separated list of tags to consider for deletion.
         Supports wildcard '*', '?', '[seq]' and '[!seq]' via Unix shell-style wildcards
     :param filter_include_untagged: Whether to consider untagged images for deletion.
+    :param dry_run: Do not actually delete packages but print output showing which packages would
+        have been deleted.
     """
     inputs = Inputs(
         image_names=image_names,
@@ -498,6 +508,7 @@ async def main(
         keep_at_least=keep_at_least,
         filter_tags=filter_tags,
         filter_include_untagged=filter_include_untagged,
+        dry_run=dry_run,
     )
     async with AsyncClient(
         headers={'accept': 'application/vnd.github.v3+json', 'Authorization': f'Bearer {token}'}


### PR DESCRIPTION
This adds a simple dry-run flag to allow for testing to easily see what would be deleted. The check for a dry run and skip of actual removal could be done even later/deeper in, but this was a very easy and clear place to put it. The image is added to the `deleted` list to follow what would happen as closely as possible, but I would be happy to remove that if desired since the image was not actually deleted.