### PR TITLE
actions/setup-python Upgrade from v4 to v5.0.0 (node16 is deprecated)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5.0.0
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11.2"
       - uses: actions/cache@v3
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5.0.0
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11.2"
       - uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11.2"
       - uses: actions/cache@v3
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11.2"
       - uses: actions/cache@v3

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: "3.11"
 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ 
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4.

See https://github.com/actions/setup-python/releases/tag/v5.0.0

This is visible in the GitHub Actions Web View:
<img width="1316" alt="Screenshot 2024-01-29 at 15 38 43" src="https://github.com/snok/container-retention-policy/assets/320064/a95706d6-1ea2-40a2-9b1d-5d452877e565">
