### PR TITLE
fix: only delete matches when using filter_tags and keep_at_least

### DIFF
--- a/main.py
+++ b/main.py
@@ -447,11 +447,11 @@ async def get_and_delete_old_versions(image_name: str, inputs: Inputs, http_clie
                 delete_image = True
                 break
 
-        if inputs.keep_at_least > 0 and not inputs.filter_tags:
-            delete_image = idx - (len(tasks) + simulated_tasks) >= inputs.keep_at_least
-        elif inputs.keep_at_least > 0 and inputs.filter_tags:
-            if delete_image:
-                delete_image = kept_images + len(tasks) + simulated_tasks >= inputs.keep_at_least
+        if inputs.keep_at_least > 0:
+            if not inputs.filter_tags:
+                delete_image = idx >= inputs.keep_at_least
+            elif delete_image:
+                delete_image = kept_images >= inputs.keep_at_least
                 kept_images += 1
 
         # Here we will handle exclusion case

--- a/main_tests.py
+++ b/main_tests.py
@@ -397,6 +397,7 @@ class TestGetAndDeleteOldVersions:
         captured = capsys.readouterr()
         assert 'Would delete image a:8.\n' in captured.out
         assert 'Would delete image a:9.\n' in captured.out
+        assert captured.out.count('Would delete image a:') == 2
 
 
 def test_inputs_bad_token_type():


### PR DESCRIPTION
This addresses the problem mentioned in #67 that keep_at_least did not behave as described in the docs:

> If used together with filter-tags parameter, keep-at-least number of image tags will be skipped from the resulting filtered set, which makes it possible to apply different retention policies based on image tag format.

The diff became long because I removed the redundant semaphore entry. Split view makes changes more clear. It's only a few lines