### PR TITLE
Fix v2 broken YAML

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -69,4 +69,4 @@ runs:
     - --cut-off="${{ inputs.cut-off }}"
     - --dry-run="${{ inputs.dry-run }}"
   env:
-    RUST_LOG=${{ inputs.log-level }}
+    RUST_LOG: ${{ inputs.log-level }}


### PR DESCRIPTION
Fix typo (using `=` rather than `:` in YAML) that breaks actions using `v2`.

Fixes #80 