### PR TITLE
Fix tests calling nonexistent or old binary build

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -87,7 +87,6 @@ pub struct Input {
 
 #[cfg(test)]
 mod tests {
-    use assert_cmd::Command;
     use clap::ValueEnum;
     use secrecy::Secret;
 
@@ -179,65 +178,5 @@ mod tests {
         );
         assert!(Account::try_from_str("").is_err());
         assert!(Account::try_from_str(" ").is_err());
-    }
-
-    #[test]
-    fn parse_input() {
-        let args_permutations = vec![
-            vec![
-                "--account=user",
-                "--token=ghs_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
-                "--image-names=foo",
-                "--image-tags=one",
-                "--shas-to-skip=",
-                "--keep-n-most-recent=0",
-                "--tag-selection=tagged",
-                "--timestamp-to-use=updated_at",
-                "--cut-off=1w",
-                "--dry-run=true",
-            ],
-            vec![
-                "--account=acme",
-                "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
-                "--image-names=\"foo bar\"",
-                "--image-tags=\"one two\"",
-                "--shas-to-skip=",
-                "--keep-n-most-recent=10",
-                "--tag-selection=untagged",
-                "--timestamp-to-use=created_at",
-                "--cut-off=1d",
-                "--dry-run=true",
-            ],
-            vec![
-                "--account=foo",
-                "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
-                "--image-names=\"foo, bar\"",
-                "--image-tags=\"one, two\"",
-                "--shas-to-skip=''",
-                "--keep-n-most-recent=999",
-                "--tag-selection=both",
-                "--timestamp-to-use=updated_at",
-                "--cut-off=1h",
-                "--dry-run=true",
-            ],
-            vec![
-                "--account=$;\u{b}\n₭↭",
-                "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
-                "--image-names=\"foo, bar\"",
-                "--image-tags=\"one, two\"",
-                "--shas-to-skip=''",
-                "--keep-n-most-recent=2",
-                "--tag-selection=both",
-                "--timestamp-to-use=updated_at",
-                "--cut-off=1h",
-                "--dry-run=true",
-            ],
-        ];
-
-        for args in args_permutations {
-            let mut cmd = Command::cargo_bin("container-retention-policy").expect("Failed to load binary");
-
-            cmd.env("CRP_TEST", "true").args(args).assert().success();
-        }
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,61 @@
+use assert_cmd::Command;
+
+#[test]
+fn parse_input() {
+    let args_permutations = vec![
+        vec![
+            "--account=user",
+            "--token=ghs_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
+            "--image-names=foo",
+            "--image-tags=one",
+            "--shas-to-skip=",
+            "--keep-n-most-recent=0",
+            "--tag-selection=tagged",
+            "--timestamp-to-use=updated_at",
+            "--cut-off=1w",
+            "--dry-run=true",
+        ],
+        vec![
+            "--account=acme",
+            "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
+            "--image-names=\"foo bar\"",
+            "--image-tags=\"one two\"",
+            "--shas-to-skip=",
+            "--keep-n-most-recent=10",
+            "--tag-selection=untagged",
+            "--timestamp-to-use=created_at",
+            "--cut-off=1d",
+            "--dry-run=true",
+        ],
+        vec![
+            "--account=foo",
+            "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
+            "--image-names=\"foo, bar\"",
+            "--image-tags=\"one, two\"",
+            "--shas-to-skip=''",
+            "--keep-n-most-recent=999",
+            "--tag-selection=both",
+            "--timestamp-to-use=updated_at",
+            "--cut-off=1h",
+            "--dry-run=true",
+        ],
+        vec![
+            "--account=$;\u{b}\n₭↭",
+            "--token=ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
+            "--image-names=\"foo, bar\"",
+            "--image-tags=\"one, two\"",
+            "--shas-to-skip=''",
+            "--keep-n-most-recent=2",
+            "--tag-selection=both",
+            "--timestamp-to-use=updated_at",
+            "--cut-off=1h",
+            "--dry-run=true",
+        ],
+    ];
+
+    for args in args_permutations {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed to load binary");
+
+        cmd.env("CRP_TEST", "true").args(args).assert().success();
+    }
+}


### PR DESCRIPTION
Binaries are not built by default with `cargo test`, unless there are integration tests to be executed, see: https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection

So the test was relying on previous binary builds (`cargo build`). Now it will always use an up to date binary since it's an integration test. See also: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html