### PR TITLE
Use provided `GITHUB_*` URL variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-clap = { version = "4.5.4", features = ["derive"]}
+clap = { version = "4.5.4", features = ["derive", "env"]}
 chrono = { version="0.4.37" , features=["serde", "clock"], default-features = false}
 color-eyre = { version = "0.6.3", default-features = false }
 humantime = "2.1.0"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -8,6 +8,9 @@ use regex::Regex;
 use tracing::Level;
 use url::Url;
 
+pub const DEFAULT_GITHUB_SERVER_URL: &str = "https://github.com";
+pub const DEFAULT_GITHUB_API_URL: &str = "https://api.github.com";
+
 pub fn vec_of_string_from_str(value: &str) -> Result<Vec<String>, Infallible> {
     let trimmed = value.trim_matches('"').trim_matches('\''); // Remove surrounding quotes
     if trimmed.is_empty() {
@@ -63,14 +66,14 @@ pub struct Input {
     #[arg(long, value_parser = try_parse_url)]
     // Use environment variable provided by GitHub before falling back to default, see also:
     // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    #[arg(env = "GITHUB_SERVER_URL", default_value = Self::DEFAULT_GITHUB_SERVER_URL)]
+    #[arg(env = "GITHUB_SERVER_URL", default_value = DEFAULT_GITHUB_SERVER_URL)]
     pub github_server_url: Url,
 
     /// The GitHub API base URL
     #[arg(long, value_parser = try_parse_url)]
     // Use environment variable provided by GitHub before falling back to default, see also:
     // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-    #[arg(env = "GITHUB_API_URL", default_value = Self::DEFAULT_GITHUB_API_URL)]
+    #[arg(env = "GITHUB_API_URL", default_value = DEFAULT_GITHUB_API_URL)]
     pub github_api_url: Url,
 
     /// The package names to target
@@ -108,11 +111,6 @@ pub struct Input {
     /// The log level to use for the tracing subscriber
     #[arg(long, global = true, default_value = "info")]
     pub(crate) log_level: Level,
-}
-
-impl Input {
-    pub const DEFAULT_GITHUB_SERVER_URL: &str = "https://github.com";
-    pub const DEFAULT_GITHUB_API_URL: &str = "https://api.github.com";
 }
 
 #[cfg(test)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -40,7 +40,7 @@ pub fn try_parse_shas_as_list(s: &str) -> Result<Vec<String>, String> {
     Ok(shas)
 }
 
-fn try_parse_url(url_str: &str) -> Result<Url, url::ParseError> {
+pub(crate) fn try_parse_url(url_str: &str) -> Result<Url, url::ParseError> {
     // Since `Url` will always add a `/` if the path is empty, we should make it consistent beforehand.
     // See also: https://github.com/servo/rust-url/issues/808
     if url_str.ends_with('/') {

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -158,7 +158,7 @@ impl PackagesClientBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::args::Input;
+    use crate::cli::args::{DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL};
     use secrecy::Secret;
 
     #[test]

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -196,8 +196,8 @@ mod tests {
 
     #[test]
     fn test_builder_generate_urls() {
-        let github_server_url = &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap();
-        let github_api_url = &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap();
+        let github_server_url = &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap();
+        let github_api_url = &Url::parse(DEFAULT_GITHUB_API_URL).unwrap();
         for account in [&Account::User, &Account::Organization("test".to_string())] {
             let builder = PackagesClientBuilder::new().generate_urls(github_server_url, github_api_url, account);
             assert!(builder.urls.is_some());
@@ -226,8 +226,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_builder_build_naked() {
-        let github_server_url = &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap();
-        let github_api_url = &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap();
+        let github_server_url = &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap();
+        let github_api_url = &Url::parse(DEFAULT_GITHUB_API_URL).unwrap();
         assert!(PackagesClientBuilder::new().build().is_err());
         assert!(PackagesClientBuilder::new()
             .generate_urls(github_server_url, github_api_url, &Account::User)

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -482,13 +482,12 @@ impl PackagesClient {
 
 #[cfg(test)]
 mod tests {
-    use crate::cli::args::Input;
+    use super::*;
+    use crate::cli::args::{DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL};
     use crate::cli::models::Account;
     use crate::client::builder::PackagesClientBuilder;
     use reqwest::header::HeaderValue;
     use secrecy::Secret;
-
-    use super::*;
 
     #[test]
     fn github_headers() {
@@ -583,19 +582,19 @@ mod tests {
         );
         assert_eq!(
             urls.list_packages_url.as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/user/packages?package_type=container&per_page=100"
+            DEFAULT_GITHUB_API_URL.to_string() + "/user/packages?package_type=container&per_page=100"
         );
         assert_eq!(
             urls.list_package_versions_url("foo").unwrap().as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/user/packages/container/foo/versions?per_page=100"
+            DEFAULT_GITHUB_API_URL.to_string() + "/user/packages/container/foo/versions?per_page=100"
         );
         assert_eq!(
             urls.delete_package_version_url("foo", &123).unwrap().as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/user/packages/container/foo/versions/123"
+            DEFAULT_GITHUB_API_URL.to_string() + "/user/packages/container/foo/versions/123"
         );
         assert_eq!(
             urls.package_version_url("foo", &123).unwrap().as_str(),
-            Input::DEFAULT_GITHUB_SERVER_URL.to_string() + "/user/packages/container/foo/123"
+            DEFAULT_GITHUB_SERVER_URL.to_string() + "/user/packages/container/foo/123"
         );
     }
 
@@ -608,19 +607,19 @@ mod tests {
         );
         assert_eq!(
             urls.list_packages_url.as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages?package_type=container&per_page=100"
+            DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages?package_type=container&per_page=100"
         );
         assert_eq!(
             urls.list_package_versions_url("foo").unwrap().as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages/container/foo/versions?per_page=100"
+            DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages/container/foo/versions?per_page=100"
         );
         assert_eq!(
             urls.delete_package_version_url("foo", &123).unwrap().as_str(),
-            Input::DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages/container/foo/versions/123"
+            DEFAULT_GITHUB_API_URL.to_string() + "/orgs/acme/packages/container/foo/versions/123"
         );
         assert_eq!(
             urls.package_version_url("foo", &123).unwrap().as_str(),
-            Input::DEFAULT_GITHUB_SERVER_URL.to_string() + "/orgs/acme/packages/container/foo/123"
+            DEFAULT_GITHUB_SERVER_URL.to_string() + "/orgs/acme/packages/container/foo/123"
         );
     }
 
@@ -655,12 +654,9 @@ mod tests {
         };
         assert!(urls.list_packages_url.as_str().contains("per_page=100"));
         assert!(urls.list_packages_url.as_str().contains("package_type=container"));
-        assert!(urls.list_packages_url.as_str().contains(Input::DEFAULT_GITHUB_API_URL));
-        assert!(urls.packages_api_base.as_str().contains(Input::DEFAULT_GITHUB_API_URL));
-        assert!(urls
-            .packages_frontend_base
-            .as_str()
-            .contains(Input::DEFAULT_GITHUB_SERVER_URL));
+        assert!(urls.list_packages_url.as_str().contains(DEFAULT_GITHUB_API_URL));
+        assert!(urls.packages_api_base.as_str().contains(DEFAULT_GITHUB_API_URL));
+        assert!(urls.packages_frontend_base.as_str().contains(DEFAULT_GITHUB_SERVER_URL));
 
         let urls = {
             let mut builder = PackagesClientBuilder::new();
@@ -674,13 +670,10 @@ mod tests {
         };
         assert!(urls.list_packages_url.as_str().contains("per_page=100"));
         assert!(urls.list_packages_url.as_str().contains("package_type=container"));
-        assert!(urls.list_packages_url.as_str().contains(Input::DEFAULT_GITHUB_API_URL));
-        assert!(urls.packages_api_base.as_str().contains(Input::DEFAULT_GITHUB_API_URL));
+        assert!(urls.list_packages_url.as_str().contains(DEFAULT_GITHUB_API_URL));
+        assert!(urls.packages_api_base.as_str().contains(DEFAULT_GITHUB_API_URL));
         assert!(urls.list_packages_url.as_str().contains("/foo/"));
         assert!(urls.packages_api_base.as_str().contains("/foo/"));
-        assert!(urls
-            .packages_frontend_base
-            .as_str()
-            .contains(Input::DEFAULT_GITHUB_SERVER_URL));
+        assert!(urls.packages_frontend_base.as_str().contains(DEFAULT_GITHUB_SERVER_URL));
     }
 }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -553,8 +553,8 @@ mod tests {
         let client = client_builder
             .create_rate_limited_services()
             .generate_urls(
-                &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap(),
-                &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap(),
+                &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap(),
+                &Url::parse(DEFAULT_GITHUB_API_URL).unwrap(),
                 &Account::User,
             )
             .build()
@@ -576,8 +576,8 @@ mod tests {
     #[test]
     fn personal_urls() {
         let urls = Urls::new(
-            &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap(),
-            &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap(),
+            &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap(),
+            &Url::parse(DEFAULT_GITHUB_API_URL).unwrap(),
             &Account::User,
         );
         assert_eq!(
@@ -601,8 +601,8 @@ mod tests {
     #[test]
     fn organization_urls() {
         let urls = Urls::new(
-            &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap(),
-            &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap(),
+            &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap(),
+            &Url::parse(DEFAULT_GITHUB_API_URL).unwrap(),
             &Account::Organization("acme".to_string()),
         );
         assert_eq!(
@@ -643,8 +643,8 @@ mod tests {
     }
     #[test]
     fn test_generate_urls() {
-        let github_server_url = &Url::try_from(Input::DEFAULT_GITHUB_SERVER_URL).unwrap();
-        let github_api_url = &Url::try_from(Input::DEFAULT_GITHUB_API_URL).unwrap();
+        let github_server_url = &Url::parse(DEFAULT_GITHUB_SERVER_URL).unwrap();
+        let github_api_url = &Url::parse(DEFAULT_GITHUB_API_URL).unwrap();
 
         let urls = {
             let mut builder = PackagesClientBuilder::new();

--- a/src/client/urls.rs
+++ b/src/client/urls.rs
@@ -4,24 +4,25 @@ use url::Url;
 
 #[derive(Debug)]
 pub struct Urls {
+    pub api_base: Url,
     pub packages_frontend_base: Url,
     pub packages_api_base: Url,
     pub list_packages_url: Url,
 }
 
 impl Urls {
-    pub fn from_account(account: &Account) -> Self {
-        let mut github_base_url = String::from("https://github.com");
-        let mut api_base_url = String::from("https://api.github.com");
+    pub fn new(github_server_url: &Url, github_api_url: &Url, account: &Account) -> Self {
+        let mut github_base_url = String::from(github_server_url.clone());
+        let mut api_base_url = String::from(github_api_url.clone());
 
         match account {
             Account::User => {
-                api_base_url += "/user/packages";
-                github_base_url += "/user/packages";
+                api_base_url += "user/packages";
+                github_base_url += "user/packages";
             }
             Account::Organization(org_name) => {
-                api_base_url += &format!("/orgs/{org_name}/packages");
-                github_base_url += &format!("/orgs/{org_name}/packages");
+                api_base_url += &format!("orgs/{org_name}/packages");
+                github_base_url += &format!("orgs/{org_name}/packages");
             }
         };
 
@@ -32,6 +33,7 @@ impl Urls {
         github_base_url += "/container";
 
         Self {
+            api_base: github_api_url.clone(),
             list_packages_url,
             packages_api_base: Url::parse(&api_base_url).expect("Failed to parse URL"),
             packages_frontend_base: Url::parse(&github_base_url).expect("Failed to parse URL"),

--- a/src/core/select_package_versions.rs
+++ b/src/core/select_package_versions.rs
@@ -326,6 +326,7 @@ mod tests {
     #[test]
     fn test_filter_by_tag_selection() {
         let urls = Urls {
+            api_base: Url::parse("https://foo.com").unwrap(),
             packages_frontend_base: Url::parse("https://foo.com").unwrap(),
             packages_api_base: Url::parse("https://foo.com").unwrap(),
             list_packages_url: Url::parse("https://foo.com").unwrap(),
@@ -441,6 +442,7 @@ mod tests {
             create_pv(0, "sha256:foobar", vec!["foo", "bar"]),
             "package",
             &Urls {
+                api_base: Url::parse("https://foo.com").unwrap(),
                 packages_frontend_base: Url::parse("https://foo.com").unwrap(),
                 packages_api_base: Url::parse("https://foo.com").unwrap(),
                 list_packages_url: Url::parse("https://foo.com").unwrap(),
@@ -457,6 +459,7 @@ mod tests {
     fn test_filter_by_matchers_permutations() {
         fn call_f(matchers: Matchers) {
             let urls = Urls {
+                api_base: Url::parse("https://foo.com").unwrap(),
                 packages_frontend_base: Url::parse("https://foo.com").unwrap(),
                 packages_api_base: Url::parse("https://foo.com").unwrap(),
                 list_packages_url: Url::parse("https://foo.com").unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 
 use color_eyre::eyre::Result;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info_span, trace, Instrument};
+use tracing::{debug, error, info, info_span, trace, Instrument};
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, EnvFilter};
 
-use crate::cli::args::Input;
+use crate::cli::args::{try_parse_url, Input, DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL};
 use crate::client::builder::PackagesClientBuilder;
 use crate::client::client::PackagesClient;
 use crate::client::models::PackageVersion;
@@ -76,6 +76,13 @@ async fn main() -> Result<()> {
     // Load and validate inputs
     let init_span = info_span!("parse input").entered();
     let input = Input::parse();
+
+    if input.github_server_url != try_parse_url(DEFAULT_GITHUB_SERVER_URL).expect("URL parse error") {
+        info!("Using provided GitHub server url: {}", input.github_server_url);
+    }
+    if input.github_api_url != try_parse_url(DEFAULT_GITHUB_API_URL).expect("URL parse error") {
+        info!("Using provided GitHub API url: {}", input.github_api_url);
+    }
 
     // TODO: Is there a better way?
     if env::var("CRP_TEST").is_ok() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
     // Create rate-limited and authorized HTTP client
     let boxed_client = Box::new(
         PackagesClientBuilder::new()
-            .generate_urls(&input.account)
+            .generate_urls(&input.github_server_url, &input.github_api_url, &input.account)
             .set_http_headers(input.token.clone())
             .expect("Failed to set HTTP headers")
             .create_rate_limited_services()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -59,3 +59,34 @@ fn parse_input() {
         cmd.env("CRP_TEST", "true").args(args).assert().success();
     }
 }
+
+#[test]
+fn url_env_parsing() {
+    let arbitrary_set_of_inputs = vec![
+        "--account=user",
+        "--token=ghs_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT",
+        "--image-names=foo",
+        "--image-tags=one",
+        "--shas-to-skip=",
+        "--keep-n-most-recent=0",
+        "--tag-selection=tagged",
+        "--timestamp-to-use=updated_at",
+        "--cut-off=1w",
+        "--dry-run=true",
+    ];
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Failed to load binary");
+
+    let output = cmd
+        .env("CRP_TEST", "true")
+        .env("RUST_LOG", "container_retention_policy=info")
+        .env("GITHUB_SERVER_URL", "http://127.0.0.1:8000")
+        .env("GITHUB_API_URL", "http://127.0.0.1:8001")
+        .args(arbitrary_set_of_inputs)
+        .output()
+        .expect("Failed to execute command");
+
+    let stderr = String::from_utf8_lossy(output.stderr.as_slice()).to_string();
+
+    assert!(stderr.contains("Using provided GitHub server url: http://127.0.0.1:8000"));
+    assert!(stderr.contains("Using provided GitHub API url: http://127.0.0.1:8001"));
+}


### PR DESCRIPTION
Here's the initial implementation of the GitHub URLs part of #86.

There is also the option of adding these variables to the CLI parameters and using the `env` clap attribute to read the defaults, but I can't think of a use case where someone would realistically want to run the action on a self-hosted GitHub instance but delete images from central GitHub or vice versa.