### PR TITLE
wip: Fetch multi-platform image digests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ name = "container-retention-policy"
 version = "3.0.0"
 dependencies = [
  "assert_cmd",
+ "base64",
  "chrono",
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-indicatif = "0.3.6"
 url = { version = "2.5.0" , default-features = false}
 urlencoding = { version="2.1.3" }
 wildmatch = { version = "2.3.3" }
+base64 = "0.22.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/justfile
+++ b/justfile
@@ -50,11 +50,11 @@ run:
     RUST_LOG=container_retention_policy=debug cargo r -- \
         --account snok \
         --token $DELETE_PACKAGES_CLASSIC_TOKEN \
-        --tag-selection untagged \
+        --tag-selection both \
         --image-names "container-retention-policy"  \
         --image-tags "!latest !test-1* !v*" \
         --shas-to-skip "" \
         --keep-n-most-recent 5 \
         --timestamp-to-use "updated_at" \
-        --cut-off 1h \
-        --dry-run false
+        --cut-off 1m \
+        --dry-run true

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -14,7 +14,6 @@ use url::Url;
 use crate::cli::models::{Account, Token};
 use crate::client::client::PackagesClient;
 use crate::client::urls::Urls;
-use base64::prelude::*;
 pub type RateLimitedService = Arc<Mutex<ConcurrencyLimit<RateLimit<Client>>>>;
 
 #[derive(Debug)]

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
-use std::time::Duration;
-
+use base64::{alphabet, engine, engine::general_purpose::GeneralPurpose, Engine as _};
 use color_eyre::eyre::Result;
 use reqwest::header::HeaderMap;
 use reqwest::Client;
 use secrecy::ExposeSecret;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tower::limit::{ConcurrencyLimit, RateLimit};
 use tower::ServiceBuilder;
@@ -14,12 +14,13 @@ use url::Url;
 use crate::cli::models::{Account, Token};
 use crate::client::client::PackagesClient;
 use crate::client::urls::Urls;
-
+use base64::prelude::*;
 pub type RateLimitedService = Arc<Mutex<ConcurrencyLimit<RateLimit<Client>>>>;
 
 #[derive(Debug)]
 pub struct PackagesClientBuilder {
     pub headers: Option<HeaderMap>,
+    pub oci_headers: Option<HeaderMap>,
     pub urls: Option<Urls>,
     pub token: Option<Token>,
     pub fetch_package_service: Option<RateLimitedService>,
@@ -33,6 +34,7 @@ impl PackagesClientBuilder {
     pub fn new() -> Self {
         Self {
             headers: None,
+            oci_headers: None,
             urls: None,
             fetch_package_service: None,
             list_packages_service: None,
@@ -51,12 +53,24 @@ impl PackagesClientBuilder {
                 Token::Temporal(token) | Token::ClassicPersonalAccess(token) => token.expose_secret(),
             }
         );
+        let engine = GeneralPurpose::new(&alphabet::STANDARD, engine::general_purpose::PAD);
+        let encoded_auth_header_value = format!(
+            "Bearer {}",
+            match &token {
+                Token::Temporal(token) | Token::ClassicPersonalAccess(token) => engine.encode(token.expose_secret()),
+            }
+        );
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", auth_header_value.as_str().parse()?);
         headers.insert("X-GitHub-Api-Version", "2022-11-28".parse()?);
         headers.insert("Accept", "application/vnd.github+json".parse()?);
         headers.insert("User-Agent", "snok/container-retention-policy".parse()?);
-        self.headers = Some(headers);
+        self.headers = Some(headers.clone());
+
+        headers.insert("Accept", "application/vnd.oci.image.index.v1+json".parse()?);
+        headers.insert("Authorization", encoded_auth_header_value.as_str().parse()?);
+        self.oci_headers = Some(headers);
+
         self.token = Some(token);
         Ok(self)
     }
@@ -143,6 +157,7 @@ impl PackagesClientBuilder {
         // Create PackageVersionsClient instance
         let client = PackagesClient {
             headers: self.headers.unwrap(),
+            oci_headers: self.oci_headers.unwrap(),
             urls: self.urls.unwrap(),
             fetch_package_service: self.fetch_package_service.unwrap(),
             list_packages_service: self.list_packages_service.unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,16 +150,27 @@ async fn main() -> Result<()> {
         *counts.remaining_requests.read().await
     );
 
-    let (deleted_packages, failed_packages) =
-        delete_package_versions(package_version_map, client, counts.clone(), input.dry_run)
-            .instrument(info_span!("deleting package versions"))
-            .await;
+    for (package, package_versions) in package_version_map.iter() {
+        info!("Print package {package}");
+        for package_version in &package_versions.tagged {
+            for tag in &package_version.metadata.container.tags {
+                info!("Print tag {tag}");
+                let digests = client.fetch_image_manifest(tag).await.unwrap();
 
-    let mut github_output = env::var("GITHUB_OUTPUT").unwrap_or_default();
-
-    github_output.push_str(&format!("deleted={}", deleted_packages.join(",")));
-    github_output.push_str(&format!("failed={}", failed_packages.join(",")));
-    env::set_var("GITHUB_OUTPUT", github_output);
+                println!("digests: {digests:?}");
+            }
+        }
+    }
+    // let (deleted_packages, failed_packages) =
+    //     delete_package_versions(package_version_map, client, counts.clone(), input.dry_run)
+    //         .instrument(info_span!("deleting package versions"))
+    //         .await;
+    //
+    // let mut github_output = env::var("GITHUB_OUTPUT").unwrap_or_default();
+    //
+    // github_output.push_str(&format!("deleted={}", deleted_packages.join(",")));
+    // github_output.push_str(&format!("failed={}", failed_packages.join(",")));
+    // env::set_var("GITHUB_OUTPUT", github_output);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::Result;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, info_span, trace, Instrument};
+use tracing::{debug, error, info_span, trace, Instrument};
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -150,27 +150,16 @@ async fn main() -> Result<()> {
         *counts.remaining_requests.read().await
     );
 
-    for (package, package_versions) in package_version_map.iter() {
-        info!("Print package {package}");
-        for package_version in &package_versions.tagged {
-            for tag in &package_version.metadata.container.tags {
-                info!("Print tag {tag}");
-                let digests = client.fetch_image_manifest(tag).await.unwrap();
+    let (deleted_packages, failed_packages) =
+        delete_package_versions(package_version_map, client, counts.clone(), input.dry_run)
+            .instrument(info_span!("deleting package versions"))
+            .await;
 
-                println!("digests: {digests:?}");
-            }
-        }
-    }
-    // let (deleted_packages, failed_packages) =
-    //     delete_package_versions(package_version_map, client, counts.clone(), input.dry_run)
-    //         .instrument(info_span!("deleting package versions"))
-    //         .await;
-    //
-    // let mut github_output = env::var("GITHUB_OUTPUT").unwrap_or_default();
-    //
-    // github_output.push_str(&format!("deleted={}", deleted_packages.join(",")));
-    // github_output.push_str(&format!("failed={}", failed_packages.join(",")));
-    // env::set_var("GITHUB_OUTPUT", github_output);
+    let mut github_output = env::var("GITHUB_OUTPUT").unwrap_or_default();
+
+    github_output.push_str(&format!("deleted={}", deleted_packages.join(",")));
+    github_output.push_str(&format!("failed={}", failed_packages.join(",")));
+    env::set_var("GITHUB_OUTPUT", github_output);
 
     Ok(())
 }


### PR DESCRIPTION
Work in progress.

Fetches image digests for the user, possibly making the ingore-shas input redundant. I thought we wouldn' be able to do this, but this seems to work:

```
curl -H "X-GitHub-Api-Version: 2022-11-28" \
     -H "Accept: application/vnd.oci.image.index.v1+json" \
     -H "Authorization: Bearer <base64-encoded token>" \
     https://ghcr.io/v2/snok%2Fcontainer-retention-policy/manifests/v3.0.0
```

Docs available at https://github.com/distribution/distribution/blob/main/docs/content/spec/api.md