### PR TITLE
Add warning to the top of the readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,12 @@
 repos:
   - repo: local
     hooks:
-      - id: test
+      - id: fmt
         name: cargo fmt
         entry: cargo fmt
         language: system
         pass_filenames: false
+        files: \.rs$
 
   - repo: local
     hooks:
@@ -14,6 +15,7 @@ repos:
         entry: cargo clippy
         language: system
         pass_filenames: false
+        files: \.rs$
 
   - repo: local
     hooks:
@@ -22,6 +24,7 @@ repos:
         entry: cargo test
         language: system
         pass_filenames: false
+        files: \.rs$
 
   - repo: local
     hooks:
@@ -30,6 +33,7 @@ repos:
         entry: cargo deny check --hide-inclusion-graph
         language: system
         pass_filenames: false
+        files: ^Cargo\.(toml|lock)$
 
   - repo: local
     hooks:
@@ -38,6 +42,7 @@ repos:
         entry: cargo +nightly udeps
         language: system
         pass_filenames: false
+        files: ^Cargo\.(toml|lock)$
 
   - repo: local
     hooks:
@@ -46,6 +51,7 @@ repos:
         entry: cargo audit
         language: system
         pass_filenames: false
+        files: ^Cargo\.(toml|lock)$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ makes sense in most cases.
 - 👮 Supports multiple token types for authentication
 - 🌱 The docker image used is sized below 10Mi, and the total runtime is a few seconds for most workloads
 
+> [!WARNING]
+> If you're building multi-arch images, see [Safely handling multi-platform/multi-arch images](#safely-handling-multi-platform-multi-arch-packages).
+
 # Content
 
 - [Usage](#usage)
@@ -335,7 +338,25 @@ The action will prioritize keeping newer package versions over older ones.
 
 ## Safely handling multi-platform (multi-arch) packages
 
-This action (or rather, naïve deletion of package version in GitHub's container registry, in general) can break your multi-platform packages. If you're hosting multi-platform packages, please implement the action as described below.
+This action (or rather, naïve deletion of package version in GitHub's container registry, in general) can break your images.
+
+### How to know whether you're safe
+
+Try and run the equivalent of this curl request:
+
+```shell
+curl -L \
+     -X GET \
+     -H "Accept: application/vnd.oci.image.index.v1+json" \
+     -H "Authorization: Bearer $(echo $PAT | base64)" \
+     -H "X-GitHub-Api-Version: 2022-11-28" \
+     https://ghcr.io/v2/snok%2Fcontainer-retention-policy/manifests/v3.0.0
+```
+
+> [!NOTE]
+> The `%2F` is the percent-encoded value for `/`. Make sure you also url-encode any symbols that might need it from the package name or tag.
+
+If the response has a `manifests` key with several elements, it is not recommended to use the action without implementing the workaround explained below:
 
 ### The problem
 

--- a/justfile
+++ b/justfile
@@ -58,3 +58,19 @@ run:
         --timestamp-to-use "updated_at" \
         --cut-off 1h \
         --dry-run false
+
+fetch-package-digests tag="v3.0.0":
+    curl -L \
+          -X GET \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            -H "Authorization: Bearer $(echo $DELETE_PACKAGES_CLASSIC_TOKEN | base64)" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://ghcr.io/v2/snok%2Fcontainer-retention-policy/manifests/{{ tag }}
+
+test:
+    curl -L \
+          -X GET \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            -H "Authorization: Bearer $(echo $DELETE_PACKAGES_CLASSIC_TOKEN | base64)" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://ghcr.io/v2/snok%2Fcontainer-retention-policy/manifests/test-5-3


### PR DESCRIPTION
Since it's easy to miss the safety-section, it seems prudent to reference it higher up in the readme.