### PR TITLE
Fix docker build warning for test script

### DIFF
--- a/.github/workflows/live_test.yaml
+++ b/.github/workflows/live_test.yaml
@@ -88,7 +88,7 @@ jobs:
           do
             randomString=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 10 2>/dev/null || echo RANDOM)
             {
-              echo "FROM alpine as builder"
+              echo "FROM alpine AS builder"
               echo "RUN echo \"$randomString\" > test.txt"
               echo "FROM scratch"
               echo "COPY --from=builder /test.txt ."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.10",
  "serde",
 ]
 
@@ -264,15 +264,15 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
 dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
  "unicode-width 0.2.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -692,14 +692,14 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.1",
+ "unit-prefix",
  "vt100",
  "web-time",
 ]
@@ -785,11 +785,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -820,11 +820,12 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "windows-sys 0.52.0",
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -835,12 +836,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -862,6 +857,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -1052,8 +1053,19 @@ version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
- "regex-automata",
- "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1064,8 +1076,14 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1186,9 +1204,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]
@@ -1527,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-indicatif"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ba258e9de86447f75edf6455fded8e5242704c6fccffe7bf8d7fb6daef1180"
+checksum = "04d4e11e0e27acef25a47f27e9435355fecdc488867fa2bc90e75b0700d2823d"
 dependencies = [
  "indicatif",
  "tracing",
@@ -1550,14 +1568,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1610,6 +1628,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"
@@ -1836,6 +1860,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39b7d07a236abaef6607536ccfaf19b396dbe3f5110ddb73d39f4562902ed382"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +1971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ clap = { version = "4.5.4", features = ["derive", "env"]}
 chrono = { version="0.4.37" , features=["serde", "clock"], default-features = false}
 color-eyre = { version = "0.6.3", default-features = false }
 humantime = "2.1.0"
-indicatif = { version = "0.17.8", default-features = false }
+indicatif = { version = "0.18.0", default-features = false }
 regex = { version = "1.10.4", default-features = false }
 reqwest = {version = "0.12.2", features = ["json", "rustls-tls"], default-features = false }
-secrecy = { version =  "0.8.0" }
+secrecy = { version = "0.10.3" }
 serde = { version = "1.0.197", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.115", default-features = false }
-tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"], default-features = false }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"], default-features = false }
 tower = { version = "0.5.2", default-features = false, features = ["limit", "util"] }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"], default-features = false }
-tracing-indicatif = "0.3.6"
+tracing-indicatif = "0.3.13"
 url = { version = "2.5.0" , default-features = false}
 urlencoding = { version="2.1.3" }
 wildmatch = { version = "2.3.3" }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -117,7 +117,7 @@ pub struct Input {
 mod tests {
     use super::*;
     use clap::ValueEnum;
-    use secrecy::Secret;
+    use secrecy::SecretString;
 
     #[test]
     fn test_vec_of_string_from_str() {
@@ -188,11 +188,15 @@ mod tests {
     fn parse_token() {
         assert_eq!(
             Token::try_from_str("ghs_U4fUiyjT4gUZKJeUEI3AX501oTqIvV0loS62").unwrap(),
-            Token::Temporal(Secret::new("ghs_U4fUiyjT4gUZKJeUEI3AX501oTqIvV0loS62".to_string()))
+            Token::Temporal(SecretString::new(Box::from(
+                "ghs_U4fUiyjT4gUZKJeUEI3AX501oTqIvV0loS62".to_string()
+            )))
         );
         assert_eq!(
             Token::try_from_str("ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT").unwrap(),
-            Token::ClassicPersonalAccess(Secret::new("ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT".to_string()))
+            Token::ClassicPersonalAccess(SecretString::new(Box::from(
+                "ghp_sSIL4kMdtzfbfDdm1MC1OU2q5DbRqA3eSszT".to_string()
+            )))
         );
     }
 

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use regex::Regex;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretString};
 use tracing::debug;
 
 #[derive(Debug, Clone, ValueEnum, PartialEq)]
@@ -23,8 +23,8 @@ pub enum TagSelection {
 /// for a list of existing token types.
 #[derive(Debug, Clone)]
 pub enum Token {
-    ClassicPersonalAccess(Secret<String>),
-    Temporal(Secret<String>),
+    ClassicPersonalAccess(SecretString),
+    Temporal(SecretString),
 }
 
 impl PartialEq for Token {
@@ -51,7 +51,7 @@ impl PartialEq for Token {
 impl Token {
     pub fn try_from_str(value: &str) -> Result<Self, String> {
         let trimmed_value = value.trim_matches('"'); // Remove surrounding quotes
-        let secret = Secret::new(trimmed_value.to_string());
+        let secret = SecretString::new(Box::from(trimmed_value));
 
         // Classic PAT
         if Regex::new(r"ghp_[a-zA-Z0-9]{36}$").unwrap().is_match(trimmed_value) {

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -165,7 +165,7 @@ impl PackagesClientBuilder {
 mod tests {
     use super::*;
     use crate::cli::args::{DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL};
-    use secrecy::Secret;
+    use secrecy::SecretString;
 
     #[test]
     fn test_builder_init() {
@@ -183,7 +183,7 @@ mod tests {
     fn test_builder_set_http_headers() {
         let builder = PackagesClientBuilder::new();
         let builder = builder
-            .set_http_headers(Token::Temporal(Secret::new("test".to_string())))
+            .set_http_headers(Token::Temporal(SecretString::new(Box::from("test".to_string()))))
             .unwrap();
         assert!(builder.headers.is_some());
         assert!(builder.token.is_some());
@@ -241,13 +241,13 @@ mod tests {
             .is_err());
         assert!(PackagesClientBuilder::new()
             .generate_urls(github_server_url, github_api_url, &Account::User)
-            .set_http_headers(Token::Temporal(Secret::new("test".to_string())))
+            .set_http_headers(Token::Temporal(SecretString::new(Box::from("test".to_string()))))
             .unwrap()
             .build()
             .is_err());
         assert!(PackagesClientBuilder::new()
             .generate_urls(github_server_url, github_api_url, &Account::User)
-            .set_http_headers(Token::Temporal(Secret::new("test".to_string())))
+            .set_http_headers(Token::Temporal(SecretString::new(Box::from("test".to_string()))))
             .unwrap()
             .create_rate_limited_services()
             .build()

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -487,7 +487,7 @@ mod tests {
     use crate::cli::models::Account;
     use crate::client::builder::PackagesClientBuilder;
     use reqwest::header::HeaderValue;
-    use secrecy::Secret;
+    use secrecy::SecretString;
 
     #[test]
     fn github_headers() {
@@ -533,7 +533,9 @@ mod tests {
         let test_string = "test".to_string();
 
         let client_builder = PackagesClientBuilder::new()
-            .set_http_headers(Token::ClassicPersonalAccess(Secret::new(test_string.clone())))
+            .set_http_headers(Token::ClassicPersonalAccess(SecretString::new(Box::from(
+                test_string.clone(),
+            ))))
             .unwrap();
 
         let set_headers = client_builder.headers.clone().unwrap();


### PR DESCRIPTION
- Downgrades tracing-subscriber to fix colored logs (https://github.com/tokio-rs/tracing/issues/3378)
- Upgrades secrecy and indicatif crates
- Fixes a warning in the live test 